### PR TITLE
feat: OS user provisioning per agent + filesystem-only terminal scoping

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -64,6 +64,7 @@ import {
   loadDefaultAgentInstructionsBundle,
   resolveDefaultAgentInstructionsBundleRole,
 } from "../services/default-agent-instructions.js";
+import { provisionAgentUser, deprovisionAgentUser } from "../services/filesystem-users.js";
 
 export function agentRoutes(db: Db) {
   const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
@@ -1417,6 +1418,8 @@ export function agentRoutes(db: Db) {
       );
     }
 
+    void provisionAgentUser({ id: agent.id, name: agent.name, role: agent.role }).catch(() => {});
+
     res.status(201).json(agent);
   });
 
@@ -1903,6 +1906,8 @@ export function agentRoutes(db: Db) {
       entityId: agent.id,
     });
 
+    void deprovisionAgentUser({ id: agent.id, name: agent.name }).catch(() => {});
+
     res.json(agent);
   });
 
@@ -1923,6 +1928,8 @@ export function agentRoutes(db: Db) {
       entityType: "agent",
       entityId: agent.id,
     });
+
+    void deprovisionAgentUser({ id: agent.id, name: agent.name }).catch(() => {});
 
     res.json({ ok: true });
   });

--- a/server/src/services/filesystem-users.ts
+++ b/server/src/services/filesystem-users.ts
@@ -1,0 +1,98 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { logger } from "../middleware/logger.js";
+
+const execAsync = promisify(exec);
+
+/**
+ * Converts an agent name to a valid Unix username.
+ * Rules: lowercase, alphanumeric + underscore + hyphen, must start with letter/underscore, max 32 chars.
+ */
+export function sanitizeUsername(name: string): string {
+  const sanitized = name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "_")
+    .replace(/^[^a-z_]/, "_")
+    .replace(/_+/g, "_")
+    .slice(0, 32)
+    .replace(/[_-]+$/, "");
+  return sanitized || "agent";
+}
+
+async function userExists(username: string): Promise<boolean> {
+  try {
+    await execAsync(`id "${username}"`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Creates an OS user for a newly hired CrewSpace agent.
+ * CEO agents are added to the sudo group for root-equivalent access.
+ * Non-fatal: errors are logged but never thrown.
+ */
+export async function provisionAgentUser(agent: {
+  id: string;
+  name: string;
+  role: string;
+}): Promise<void> {
+  const username = sanitizeUsername(agent.name);
+
+  if (await userExists(username)) {
+    logger.info({ username, agentId: agent.id }, "filesystem-users: user already exists, skipping");
+    return;
+  }
+
+  try {
+    await execAsync(
+      `useradd --create-home --shell /bin/bash --comment "crewspace-agent:${agent.id}" "${username}"`,
+    );
+    logger.info({ username, agentId: agent.id, role: agent.role }, "filesystem-users: created OS user");
+  } catch (err) {
+    logger.error({ err, username, agentId: agent.id }, "filesystem-users: failed to create OS user");
+    return;
+  }
+
+  if (agent.role === "ceo") {
+    // Try sudo (Debian/Ubuntu) then wheel (RHEL/CentOS/Fedora)
+    let granted = false;
+    for (const group of ["sudo", "wheel"]) {
+      try {
+        await execAsync(`getent group "${group}"`);
+        await execAsync(`usermod -aG "${group}" "${username}"`);
+        logger.info({ username, group }, "filesystem-users: granted elevated access to CEO agent");
+        granted = true;
+        break;
+      } catch {
+        // group doesn't exist, try next
+      }
+    }
+    if (!granted) {
+      logger.warn({ username }, "filesystem-users: no sudo/wheel group found — CEO agent created without elevated access");
+    }
+  }
+}
+
+/**
+ * Removes the OS user for a terminated/deleted CrewSpace agent.
+ * Non-fatal: errors are logged but never thrown.
+ */
+export async function deprovisionAgentUser(agent: {
+  id: string;
+  name: string;
+}): Promise<void> {
+  const username = sanitizeUsername(agent.name);
+
+  if (!(await userExists(username))) {
+    return;
+  }
+
+  try {
+    await execAsync(`userdel --remove "${username}"`);
+    logger.info({ username, agentId: agent.id }, "filesystem-users: removed OS user");
+  } catch (err) {
+    logger.error({ err, username, agentId: agent.id }, "filesystem-users: failed to remove OS user");
+  }
+}

--- a/server/src/services/filesystem-users.ts
+++ b/server/src/services/filesystem-users.ts
@@ -47,7 +47,7 @@ export async function provisionAgentUser(agent: {
 
   try {
     await execAsync(
-      `useradd --create-home --shell /bin/bash --comment "crewspace-agent:${agent.id}" "${username}"`,
+      `sudo useradd --create-home --shell /bin/bash --comment "crewspace-agent:${agent.id}" "${username}"`,
     );
     logger.info({ username, agentId: agent.id, role: agent.role }, "filesystem-users: created OS user");
   } catch (err) {
@@ -61,7 +61,7 @@ export async function provisionAgentUser(agent: {
     for (const group of ["sudo", "wheel"]) {
       try {
         await execAsync(`getent group "${group}"`);
-        await execAsync(`usermod -aG "${group}" "${username}"`);
+        await execAsync(`sudo usermod -aG "${group}" "${username}"`);
         logger.info({ username, group }, "filesystem-users: granted elevated access to CEO agent");
         granted = true;
         break;
@@ -90,7 +90,7 @@ export async function deprovisionAgentUser(agent: {
   }
 
   try {
-    await execAsync(`userdel --remove "${username}"`);
+    await execAsync(`sudo userdel --remove "${username}"`);
     logger.info({ username, agentId: agent.id }, "filesystem-users: removed OS user");
   } catch (err) {
     logger.error({ err, username, agentId: agent.id }, "filesystem-users: failed to remove OS user");

--- a/server/src/services/hire-hook.ts
+++ b/server/src/services/hire-hook.ts
@@ -5,6 +5,7 @@ import type { HireApprovedPayload } from "@crewspaceai/adapter-utils";
 import { findServerAdapter } from "../adapters/registry.js";
 import { logger } from "../middleware/logger.js";
 import { logActivity } from "./activity-log.js";
+import { provisionAgentUser } from "./filesystem-users.js";
 
 const HIRE_APPROVED_MESSAGE =
   "Tell your user that your hire was approved, now they should assign you a task in CrewSpace or ask you to create issues.";
@@ -38,6 +39,8 @@ export async function notifyHireApproved(
     logger.warn({ companyId, agentId, source, sourceId }, "hire hook: agent not found in company, skipping");
     return;
   }
+
+  void provisionAgentUser({ id: row.id, name: row.name, role: row.role ?? "general" }).catch(() => {});
 
   const adapterType = row.adapterType ?? "process";
   const adapter = findServerAdapter(adapterType);


### PR DESCRIPTION
Closes #49

## Summary

- **New service** `filesystem-users.ts` — mirrors every agent hire/termination as a real OS user account via `sudo useradd` / `sudo userdel`
- **CEO = root** — CEO-role agents are automatically added to `sudo`/`wheel` group on hire, giving root-equivalent filesystem access. All commands run via `sudo` from the CEO's privileged terminal
- **Full lifecycle coverage** — provisioning fires on direct creation and board-approval hires; deprovisioning fires on terminate and delete
- **Terminal scoping** — `.claude/settings.local.json` restricts the Claude Code terminal to filesystem operations only (blocks `WebFetch`, `WebSearch`, `curl`, network tools, package managers)

## Test plan

- [ ] Hire a new agent directly via `POST /companies/:id/agents` — verify OS user created with `id <username>`
- [ ] Hire a CEO-role agent — verify `groups <username>` includes `sudo` or `wheel`
- [ ] Hire an agent via approval flow — verify OS user created after board approves
- [ ] Terminate an agent — verify OS user removed with `id <username>` returning "no such user"
- [ ] Delete an agent — same verification as terminate
- [ ] Hire agent with special characters in name (e.g. "My Agent #1") — verify username sanitizes to `my_agent_1`
- [ ] Verify `sudo useradd` fails gracefully (non-fatal) if server process lacks sudo — agent creation should still succeed

https://claude.ai/code/session_014VozAw64xrVMky6pjbaRJN
