### PR TITLE
perf(ui): reduce poll frequency and memoize list row components

### DIFF
--- a/ui/src/components/EntityRow.tsx
+++ b/ui/src/components/EntityRow.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { Link } from "@/lib/router";
 import { cn } from "../lib/utils";
 
@@ -14,7 +14,7 @@ interface EntityRowProps {
   className?: string;
 }
 
-export function EntityRow({
+export const EntityRow = memo(function EntityRow({
   leading,
   identifier,
   title,
@@ -66,4 +66,4 @@ export function EntityRow({
       {content}
     </div>
   );
-}
+});

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import type { Issue } from "@crewspaceai/shared";
 import { Link } from "@/lib/router";
 import { X } from "lucide-react";
@@ -25,7 +25,7 @@ interface IssueRowProps {
   className?: string;
 }
 
-export function IssueRow({
+export const IssueRow = memo(function IssueRow({
   issue,
   issueLinkState,
   selected = false,
@@ -155,4 +155,4 @@ export function IssueRow({
       ) : null}
     </Link>
   );
-}
+});

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -30,7 +30,8 @@ if ("serviceWorker" in navigator) {
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30_000,
+      staleTime: 60_000,
+      gcTime: 600_000,
       refetchOnWindowFocus: true,
     },
   },

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -253,7 +253,7 @@ export function IssueDetail() {
     queryKey: queryKeys.issues.runs(issueId!),
     queryFn: () => activityApi.runsForIssue(issueId!),
     enabled: !!issueId,
-    refetchInterval: 5000,
+    refetchInterval: 10_000,
   });
 
   const { data: linkedApprovals } = useQuery({
@@ -272,14 +272,14 @@ export function IssueDetail() {
     queryKey: queryKeys.issues.liveRuns(issueId!),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId!),
     enabled: !!issueId,
-    refetchInterval: 3000,
+    refetchInterval: 5_000,
   });
 
   const { data: activeRun } = useQuery({
     queryKey: queryKeys.issues.activeRun(issueId!),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId!),
     enabled: !!issueId,
-    refetchInterval: 3000,
+    refetchInterval: 5_000,
   });
 
   const hasLiveRuns = (liveRuns ?? []).length > 0 || !!activeRun;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **IssueDetail polling**: `linkedRuns` 5s→10s, `liveRuns`/`activeRun` 3s→5s — cuts ~40% of heartbeat requests per open issue
- **React.memo**: `IssueRow` and `EntityRow` now skip re-renders when parent re-renders but their props are unchanged
- **QueryClient defaults**: `staleTime` 30s→60s + `gcTime: 600s` — halves background refetches globally and keeps cache hot for 10 minutes

## Details

### Poll rate reduction (`IssueDetail.tsx`)
Three separate polling queries on the issue detail page were hitting the server every 3–5 seconds. Relaxed to 5–10s — live feel is preserved while server load is meaningfully reduced.

### Memoized row components (`IssueRow.tsx`, `EntityRow.tsx`)
Issue and agent lists re-render frequently (parent state changes, sidebar updates, etc.). Wrapping with `React.memo` ensures each row only re-renders when its own props change.

### QueryClient tuning (`main.tsx`)
- `staleTime 60_000`: data stays fresh twice as long before a background refetch is triggered
- `gcTime 600_000`: inactive query cache is kept in memory for 10 min so navigating back to a page is instant

## Test plan
- [ ] Open an issue detail page and confirm runs/live status still update within ~5–10s
- [ ] Navigate between Issues list and other pages — confirm no visible lag from stale data
- [ ] Office page — confirm agent animations and camera still work (frameloop left unchanged)

https://claude.ai/code/session_01SuMiC9c331xRGngBC1WCLp
EOF
)