### PR TITLE
feat: UI chat persistence + Shared Workspace page

### DIFF
--- a/server/src/routes/shared-workspace.ts
+++ b/server/src/routes/shared-workspace.ts
@@ -21,7 +21,8 @@ export function sharedWorkspaceRoutes(_db: Db, sharedWorkspaceDir: string) {
     "/companies/:companyId/shared-workspace/files",
     upload.single("file"),
     async (req, res) => {
-      assertCompanyAccess(req, req.params.companyId);
+      const companyId = req.params["companyId"] as string;
+      assertCompanyAccess(req, companyId);
       if (!req.file) {
         res.status(400).json({ error: "No file uploaded" });
         return;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -43,6 +43,7 @@ import { AgentChat } from "./pages/AgentChat";
 const Office = lazy(() => import("./pages/Office").then((m) => ({ default: m.Office })));
 import { Blockers } from "./pages/Blockers";
 import { CeoTerminal } from "./pages/CeoTerminal";
+import { SharedWorkspace } from "./pages/SharedWorkspace";
 import { TaskboardV2 } from "./pages/TaskboardV2";
 import { NewAgent } from "./pages/NewAgent";
 import { AuthPage } from "./pages/Auth";
@@ -146,6 +147,7 @@ function boardRoutes() {
       <Route path="agent-chat" element={<AgentChat />} />
       <Route path="office" element={<Suspense fallback={null}><Office /></Suspense>} />
       <Route path="terminal" element={<CeoTerminal />} />
+      <Route path="workspace" element={<SharedWorkspace />} />
       <Route path="blockers" element={<Blockers />} />
       <Route path="taskboard" element={<TaskboardV2 />} />
       <Route path="agents" element={<Navigate to="/agents/all" replace />} />

--- a/ui/src/api/chatSessions.ts
+++ b/ui/src/api/chatSessions.ts
@@ -1,0 +1,52 @@
+import { api } from "./client";
+
+export interface ChatSessionParticipant {
+  agentId: string;
+  agentName: string | null;
+  agentIcon: string | null;
+  agentStatus: string | null;
+}
+
+export interface ChatMessageRecord {
+  id: string;
+  sessionId: string;
+  role: string;
+  content: string;
+  agentId: string | null;
+  createdAt: string;
+}
+
+export interface ChatSessionSummary {
+  id: string;
+  companyId: string;
+  primaryAgentId: string;
+  name: string | null;
+  createdAt: string;
+  updatedAt: string;
+  participants: ChatSessionParticipant[];
+  lastMessage: { content: string; role: string; createdAt: string } | null;
+}
+
+export interface ChatSessionDetail extends ChatSessionSummary {
+  messages: ChatMessageRecord[];
+}
+
+export const chatSessionsApi = {
+  list: (companyId: string) =>
+    api.get<ChatSessionSummary[]>(`/companies/${companyId}/chat-sessions`),
+
+  get: (id: string) =>
+    api.get<ChatSessionDetail>(`/chat-sessions/${id}`),
+
+  create: (companyId: string, input: { primaryAgentId: string; participantIds?: string[]; name?: string }) =>
+    api.post<ChatSessionSummary>(`/companies/${companyId}/chat-sessions`, input),
+
+  rename: (id: string, name: string) =>
+    api.patch<ChatSessionSummary>(`/chat-sessions/${id}`, { name }),
+
+  remove: (id: string) =>
+    api.delete<void>(`/chat-sessions/${id}`),
+
+  appendMessage: (id: string, input: { role: string; content: string; agentId?: string | null }) =>
+    api.post<ChatMessageRecord>(`/chat-sessions/${id}/messages`, input),
+};

--- a/ui/src/api/sharedWorkspace.ts
+++ b/ui/src/api/sharedWorkspace.ts
@@ -1,0 +1,26 @@
+import { api } from "./client";
+
+export interface WorkspaceFile {
+  name: string;
+  sizeBytes: number;
+}
+
+export const sharedWorkspaceApi = {
+  list: (companyId: string) =>
+    api.get<WorkspaceFile[]>(`/companies/${companyId}/shared-workspace/files`),
+
+  upload: (companyId: string, file: File) => {
+    const form = new FormData();
+    form.append("file", file);
+    return api.postForm<WorkspaceFile>(`/companies/${companyId}/shared-workspace/files`, form);
+  },
+
+  download: (companyId: string, filename: string) =>
+    fetch(`/api/companies/${companyId}/shared-workspace/files/${encodeURIComponent(filename)}`, {
+      credentials: "include",
+      cache: "no-store",
+    }),
+
+  remove: (companyId: string, filename: string) =>
+    api.delete<void>(`/companies/${companyId}/shared-workspace/files/${encodeURIComponent(filename)}`),
+};

--- a/ui/src/components/ChatSidebar.tsx
+++ b/ui/src/components/ChatSidebar.tsx
@@ -18,7 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { AgentIcon } from "./AgentIconPicker";
 import { cn } from "@/lib/utils";
-import { useChat, type ChatSession } from "../context/ChatContext";
+import { useChat, type ChatSession, type ChatParticipant } from "../context/ChatContext";
 import { useCompany } from "../context/CompanyContext";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../lib/queryKeys";
@@ -320,10 +320,11 @@ function ChatArea({
   session: ChatSession;
   allAgents: Agent[];
   companyId: string | undefined;
-  onUpdate: (messages: ChatMessage[], participants: Agent[]) => void;
+  onUpdate: (messages: ChatMessage[], participants: ChatParticipant[]) => void;
   onClose: () => void;
 }) {
   const { openNewIssue } = useDialog();
+  const { persistMessage } = useChat();
   const queryClient = useQueryClient();
   const isMountedRef = useRef(true);
   const abortRef = useRef<AbortController | null>(null);
@@ -335,7 +336,7 @@ function ChatArea({
     };
   }, []);
 
-  const [participants, setParticipants] = useState<Agent[]>([]);
+  const [participants, setParticipants] = useState<ChatParticipant[]>([]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
 
   // Sync session data only when switching to a different session (not on every content change)
@@ -392,6 +393,7 @@ function ChatArea({
     const fullHistory: ChatMessage[] = [...messages, userMsg];
     setMessages((prev) => [...prev, userMsg]);
     setInput("");
+    persistMessage(session.id, "user", text);
 
     abortRef.current = new AbortController();
     for (const agent of participants) {
@@ -406,7 +408,7 @@ function ChatArea({
 
       let finalContent = "";
       const streamResult = await streamAgentChat(
-        agent,
+        agent as unknown as Agent,
         fullHistory,
         companyId,
         abortRef.current.signal,
@@ -428,6 +430,7 @@ function ChatArea({
       }
 
       setTypingAgentId(null);
+      if (finalContent.trim()) persistMessage(session.id, "agent", finalContent, agent.id);
 
       // Save agent response as memory + task solution (non-blocking)
       if (finalContent.trim() && companyId && isMountedRef.current) {
@@ -560,7 +563,7 @@ function ChatArea({
           ))}
           <AddParticipantMenu
             allAgents={allAgents}
-            participants={participants}
+            participants={participants as unknown as Agent[]}
             onAdd={addParticipant}
           />
         </div>
@@ -750,7 +753,7 @@ export function ChatSidebar({ onClose }: { onClose?: () => void }) {
   );
 
   const handleUpdate = useCallback(
-    (messages: ChatMessage[], participants: Agent[]) => {
+    (messages: ChatMessage[], participants: ChatParticipant[]) => {
       if (activeSessionId) updateSession(activeSessionId, messages, participants);
     },
     [activeSessionId, updateSession],

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   ChevronRight,
   Building2,
   TerminalSquare,
+  FolderOpen,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { SidebarSection } from "./SidebarSection";
@@ -151,6 +152,7 @@ export function Sidebar() {
           />
           <SidebarNavItem to="/office" label="3D Office" icon={Building2} />
           <SidebarNavItem to="/terminal" label="Console" icon={TerminalSquare} />
+          <SidebarNavItem to="/workspace" label="Workspace" icon={FolderOpen} />
         </SidebarSection>
 
         {/* System */}

--- a/ui/src/context/ChatContext.tsx
+++ b/ui/src/context/ChatContext.tsx
@@ -1,7 +1,15 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from "react";
+import { useCompany } from "./CompanyContext";
+import { chatSessionsApi } from "../api/chatSessions";
 
 const MAX_SESSIONS = 50;
-import type { Agent } from "@crewspaceai/shared";
+
+export interface ChatParticipant {
+  id: string;
+  name: string;
+  icon: string | null;
+  status: string;
+}
 
 export interface ChatMessage {
   id: string;
@@ -14,7 +22,7 @@ export interface ChatMessage {
 export interface ChatSession {
   id: string;
   primaryAgentId: string;
-  participants: Agent[];
+  participants: ChatParticipant[];
   messages: ChatMessage[];
   updatedAt: Date;
   name?: string;
@@ -24,69 +32,185 @@ interface ChatContextValue {
   sessions: ChatSession[];
   activeSessionId: string | null;
   setActiveSessionId: (id: string | null) => void;
-  openChatWithAgent: (agent: Agent) => void;
-  openChatWithAgents: (agents: Agent[]) => void;
-  updateSession: (id: string, messages: ChatMessage[], participants: Agent[]) => void;
+  openChatWithAgent: (agent: ChatParticipant) => void;
+  openChatWithAgents: (agents: ChatParticipant[]) => void;
+  updateSession: (id: string, messages: ChatMessage[], participants: ChatParticipant[]) => void;
   deleteSession: (id: string) => void;
   renameSession: (id: string, name: string) => void;
+  persistMessage: (sessionId: string, role: string, content: string, agentId?: string | null) => void;
   isChatOpen: boolean;
   setIsChatOpen: (open: boolean) => void;
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null);
 
+function isServerSession(id: string) {
+  return !id.startsWith("session-");
+}
+
+function serverToLocal(s: Awaited<ReturnType<typeof chatSessionsApi.list>>[number]): ChatSession {
+  return {
+    id: s.id,
+    primaryAgentId: s.primaryAgentId,
+    name: s.name ?? undefined,
+    updatedAt: new Date(s.updatedAt),
+    participants: s.participants.map((p) => ({
+      id: p.agentId,
+      name: p.agentName ?? "Agent",
+      icon: p.agentIcon,
+      status: p.agentStatus ?? "active",
+    })),
+    messages: [],
+  };
+}
+
 export function ChatProvider({ children }: { children: ReactNode }) {
+  const { selectedCompanyId } = useCompany();
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [isChatOpen, setIsChatOpen] = useState(false);
 
-  const openChatWithAgent = useCallback((agent: Agent) => {
-    setIsChatOpen(true);
+  // Load sessions from server when company changes
+  useEffect(() => {
+    if (!selectedCompanyId) {
+      setSessions([]);
+      return;
+    }
+    chatSessionsApi.list(selectedCompanyId).then((serverSessions) => {
+      setSessions(serverSessions.map(serverToLocal));
+    }).catch(() => { /* server may not be available */ });
+  }, [selectedCompanyId]);
+
+  // Load messages for active session on demand
+  useEffect(() => {
+    if (!activeSessionId || !isServerSession(activeSessionId)) return;
     setSessions((prev) => {
-      const existing = prev.find(
-        (s) => s.primaryAgentId === agent.id && s.participants.length === 1,
-      );
-      if (existing) {
-        setActiveSessionId(existing.id);
+      const session = prev.find((s) => s.id === activeSessionId);
+      if (!session || session.messages.length > 0) return prev; // already loaded
+      return prev; // trigger async fetch below
+    });
+
+    // Check if messages already loaded synchronously before fetching
+    setSessions((prev) => {
+      const session = prev.find((s) => s.id === activeSessionId);
+      if (!session || session.messages.length > 0) return prev;
+      // Kick off async fetch
+      chatSessionsApi.get(activeSessionId).then((full) => {
+        if (!full) return;
+        setSessions((current) =>
+          current.map((s) =>
+            s.id === activeSessionId
+              ? {
+                  ...s,
+                  participants: full.participants.map((p) => ({
+                    id: p.agentId,
+                    name: p.agentName ?? "Agent",
+                    icon: p.agentIcon,
+                    status: p.agentStatus ?? "active",
+                  })),
+                  messages: full.messages.map((m) => ({
+                    id: m.id,
+                    role: m.role === "user" ? "user" : "agent",
+                    agentId: m.agentId ?? undefined,
+                    content: m.content,
+                    ts: new Date(m.createdAt),
+                  })),
+                }
+              : s,
+          ),
+        );
+      }).catch(() => {});
+      return prev;
+    });
+  }, [activeSessionId]);
+
+  const openChatWithAgent = useCallback(
+    async (agent: ChatParticipant) => {
+      setIsChatOpen(true);
+
+      // Check for existing single-agent session with this agent
+      let existingId: string | null = null;
+      setSessions((prev) => {
+        const found = prev.find(
+          (s) => s.primaryAgentId === agent.id && s.participants.length === 1,
+        );
+        if (found) existingId = found.id;
         return prev;
+      });
+      if (existingId) {
+        setActiveSessionId(existingId);
+        return;
       }
+
+      let sessionId = `session-${Date.now()}`;
+      if (selectedCompanyId) {
+        try {
+          const created = await chatSessionsApi.create(selectedCompanyId, {
+            primaryAgentId: agent.id,
+            participantIds: [],
+          });
+          sessionId = created.id;
+        } catch { /* fall back to temp id */ }
+      }
+
       const newSession: ChatSession = {
-        id: `session-${Date.now()}`,
+        id: sessionId,
         primaryAgentId: agent.id,
         participants: [agent],
         messages: [],
         updatedAt: new Date(),
       };
       setActiveSessionId(newSession.id);
-      const next = [...prev, newSession];
-      return next.length > MAX_SESSIONS
-        ? next.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()).slice(0, MAX_SESSIONS)
-        : next;
-    });
-  }, []);
+      setSessions((prev) => {
+        const next = [...prev, newSession];
+        return next.length > MAX_SESSIONS
+          ? next.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()).slice(0, MAX_SESSIONS)
+          : next;
+      });
+    },
+    [selectedCompanyId],
+  );
 
-  const openChatWithAgents = useCallback((agents: Agent[]) => {
-    if (agents.length === 0) return;
-    if (agents.length === 1) { openChatWithAgent(agents[0]); return; }
-    setIsChatOpen(true);
-    setSessions((prev) => {
+  const openChatWithAgents = useCallback(
+    async (agents: ChatParticipant[]) => {
+      if (agents.length === 0) return;
+      if (agents.length === 1) {
+        openChatWithAgent(agents[0]);
+        return;
+      }
+      setIsChatOpen(true);
+
+      let sessionId = `session-${Date.now()}`;
+      if (selectedCompanyId) {
+        try {
+          const created = await chatSessionsApi.create(selectedCompanyId, {
+            primaryAgentId: agents[0].id,
+            participantIds: agents.slice(1).map((a) => a.id),
+          });
+          sessionId = created.id;
+        } catch { /* fall back to temp id */ }
+      }
+
       const newSession: ChatSession = {
-        id: `session-${Date.now()}`,
+        id: sessionId,
         primaryAgentId: agents[0].id,
         participants: agents,
         messages: [],
         updatedAt: new Date(),
       };
       setActiveSessionId(newSession.id);
-      const next = [...prev, newSession];
-      return next.length > MAX_SESSIONS
-        ? next.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()).slice(0, MAX_SESSIONS)
-        : next;
-    });
-  }, [openChatWithAgent]);
+      setSessions((prev) => {
+        const next = [...prev, newSession];
+        return next.length > MAX_SESSIONS
+          ? next.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()).slice(0, MAX_SESSIONS)
+          : next;
+      });
+    },
+    [selectedCompanyId, openChatWithAgent],
+  );
 
   const updateSession = useCallback(
-    (id: string, messages: ChatMessage[], participants: Agent[]) => {
+    (id: string, messages: ChatMessage[], participants: ChatParticipant[]) => {
       setSessions((prev) =>
         prev.map((s) =>
           s.id === id ? { ...s, messages, participants, updatedAt: new Date() } : s,
@@ -99,18 +223,43 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const deleteSession = useCallback((id: string) => {
     setSessions((prev) => prev.filter((s) => s.id !== id));
     setActiveSessionId((prev) => (prev === id ? null : prev));
+    if (isServerSession(id)) {
+      chatSessionsApi.remove(id).catch(() => {});
+    }
   }, []);
 
   const renameSession = useCallback((id: string, name: string) => {
     setSessions((prev) =>
       prev.map((s) => (s.id === id ? { ...s, name: name.trim() || undefined } : s)),
     );
+    if (isServerSession(id)) {
+      chatSessionsApi.rename(id, name.trim()).catch(() => {});
+    }
   }, []);
 
+  const persistMessage = useCallback(
+    (sessionId: string, role: string, content: string, agentId?: string | null) => {
+      if (!isServerSession(sessionId) || !content.trim()) return;
+      chatSessionsApi.appendMessage(sessionId, { role, content, agentId }).catch(() => {});
+    },
+    [],
+  );
 
   return (
     <ChatContext.Provider
-      value={{ sessions, activeSessionId, setActiveSessionId, openChatWithAgent, openChatWithAgents, updateSession, deleteSession, renameSession, isChatOpen, setIsChatOpen }}
+      value={{
+        sessions,
+        activeSessionId,
+        setActiveSessionId,
+        openChatWithAgent,
+        openChatWithAgents,
+        updateSession,
+        deleteSession,
+        renameSession,
+        persistMessage,
+        isChatOpen,
+        setIsChatOpen,
+      }}
     >
       {children}
     </ChatContext.Provider>

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -153,4 +153,11 @@ export const queryKeys = {
     burndown: (sprintId: string) => ["sprints", "burndown", sprintId] as const,
     summary: (sprintId: string) => ["sprints", "summary", sprintId] as const,
   },
+  chatSessions: {
+    list: (companyId: string) => ["chat-sessions", companyId] as const,
+    detail: (id: string) => ["chat-sessions", "detail", id] as const,
+  },
+  sharedWorkspace: {
+    files: (companyId: string) => ["shared-workspace", "files", companyId] as const,
+  },
 };

--- a/ui/src/pages/AgentChat.tsx
+++ b/ui/src/pages/AgentChat.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { AgentIcon } from "@/components/AgentIconPicker";
 import { cn } from "@/lib/utils";
-import { useChat, type ChatSession, type ChatMessage } from "../context/ChatContext";
+import { useChat, type ChatSession, type ChatMessage, type ChatParticipant } from "../context/ChatContext";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
 import { agentsApi } from "../api/agents";
@@ -303,9 +303,10 @@ function ChatArea({ session, allAgents, companyId, onUpdate }: {
   session: ChatSession;
   allAgents: Agent[];
   companyId: string | undefined;
-  onUpdate: (messages: ChatMessage[], participants: Agent[]) => void;
+  onUpdate: (messages: ChatMessage[], participants: ChatParticipant[]) => void;
 }) {
   const { openNewIssue } = useDialog();
+  const { persistMessage } = useChat();
   const queryClient = useQueryClient();
   const isMountedRef = useRef(true);
   const abortRef = useRef<AbortController | null>(null);
@@ -317,7 +318,7 @@ function ChatArea({ session, allAgents, companyId, onUpdate }: {
     };
   }, []);
 
-  const [participants, setParticipants] = useState<Agent[]>([]);
+  const [participants, setParticipants] = useState<ChatParticipant[]>([]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
 
   useEffect(() => {
@@ -358,6 +359,7 @@ function ChatArea({ session, allAgents, companyId, onUpdate }: {
     const fullHistory: ChatMessage[] = [...messages, userMsg];
     setMessages((prev) => [...prev, userMsg]);
     setInput("");
+    persistMessage(session.id, "user", text);
 
     abortRef.current = new AbortController();
     for (const agent of participants) {
@@ -368,7 +370,7 @@ function ChatArea({ session, allAgents, companyId, onUpdate }: {
       setMessages((prev) => [...prev, { id: streamingId, role: "agent", agentId: agent.id, content: "", ts: new Date() }]);
 
       let finalContent = "";
-      const streamResult = await streamAgentChat(agent, fullHistory, companyId, abortRef.current.signal, (partial) => {
+      const streamResult = await streamAgentChat(agent as unknown as Agent, fullHistory, companyId, abortRef.current.signal, (partial) => {
         if (!isMountedRef.current) return;
         finalContent = partial;
         setMessages((prev) => prev.map((m) => m.id === streamingId ? { ...m, content: partial } : m));
@@ -380,6 +382,7 @@ function ChatArea({ session, allAgents, companyId, onUpdate }: {
       }
 
       setTypingAgentId(null);
+      if (finalContent.trim()) persistMessage(session.id, "agent", finalContent, agent.id);
 
       if (finalContent.trim() && companyId && isMountedRef.current) {
         setSavingMemory(true);
@@ -470,7 +473,7 @@ function ChatArea({ session, allAgents, companyId, onUpdate }: {
               )}
             </div>
           ))}
-          <AddParticipantMenu allAgents={allAgents} participants={participants} onAdd={addParticipant} />
+          <AddParticipantMenu allAgents={allAgents} participants={participants as unknown as Agent[]} onAdd={addParticipant} />
         </div>
       </div>
 
@@ -618,7 +621,7 @@ function EmptyChat({ onNewChat }: { onNewChat: () => void }) {
 // ── Main Page ─────────────────────────────────────────────────────────────────
 
 export function AgentChat() {
-  const { sessions, activeSessionId, setActiveSessionId, openChatWithAgents, updateSession, deleteSession, renameSession } = useChat();
+  const { sessions, activeSessionId, setActiveSessionId, openChatWithAgents, updateSession, deleteSession, renameSession } = useChat(); // persistMessage used inside ChatArea
   const { selectedCompanyId } = useCompany();
 
   const { data: agents } = useQuery({
@@ -633,7 +636,7 @@ export function AgentChat() {
   const activeSession = useMemo(() => sessions.find((s) => s.id === activeSessionId) ?? null, [sessions, activeSessionId]);
   const sorted = useMemo(() => [...sessions].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()), [sessions]);
 
-  const handleUpdate = useCallback((messages: ChatMessage[], participants: Agent[]) => {
+  const handleUpdate = useCallback((messages: ChatMessage[], participants: ChatParticipant[]) => {
     if (activeSessionId) updateSession(activeSessionId, messages, participants);
   }, [activeSessionId, updateSession]);
 

--- a/ui/src/pages/SharedWorkspace.tsx
+++ b/ui/src/pages/SharedWorkspace.tsx
@@ -1,0 +1,210 @@
+import { useRef, useState, useCallback, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { FolderOpen, Upload, Trash2, Download, FileText, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useCompany } from "../context/CompanyContext";
+import { sharedWorkspaceApi, type WorkspaceFile } from "../api/sharedWorkspace";
+import { queryKeys } from "../lib/queryKeys";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function FileRow({ file, companyId, onDelete }: { file: WorkspaceFile; companyId: string; onDelete: (name: string) => void }) {
+  const [downloading, setDownloading] = useState(false);
+
+  const handleDownload = async () => {
+    setDownloading(true);
+    try {
+      const res = await sharedWorkspaceApi.download(companyId, file.name);
+      if (!res.ok) throw new Error("Download failed");
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = file.name;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch { /* silently ignore */ } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <div className="group flex items-center gap-3 px-4 py-3 border-b border-border/40 hover:bg-accent/30 transition-colors">
+      <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+      <span className="flex-1 text-sm text-foreground truncate font-medium">{file.name}</span>
+      <span className="text-xs text-muted-foreground tabular-nums shrink-0">{formatBytes(file.sizeBytes)}</span>
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+        <button
+          onClick={handleDownload}
+          disabled={downloading}
+          className="flex items-center justify-center w-7 h-7 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+          title="Download"
+        >
+          <Download className="h-3.5 w-3.5" />
+        </button>
+        <button
+          onClick={() => onDelete(file.name)}
+          className="flex items-center justify-center w-7 h-7 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors"
+          title="Delete"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SharedWorkspace() {
+  const { selectedCompanyId } = useCompany();
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const { setBreadcrumbs } = useBreadcrumbs();
+  useEffect(() => { setBreadcrumbs([{ label: "Workspace" }]); }, [setBreadcrumbs]);
+
+  const { data: files, isLoading } = useQuery({
+    queryKey: queryKeys.sharedWorkspace.files(selectedCompanyId!),
+    queryFn: () => sharedWorkspaceApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: (file: File) => sharedWorkspaceApi.upload(selectedCompanyId!, file),
+    onSuccess: () => {
+      setUploadError(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.sharedWorkspace.files(selectedCompanyId!) });
+    },
+    onError: (err: Error) => {
+      setUploadError(err.message ?? "Upload failed");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (name: string) => sharedWorkspaceApi.remove(selectedCompanyId!, name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.sharedWorkspace.files(selectedCompanyId!) });
+    },
+  });
+
+  const handleFiles = useCallback((fileList: FileList | null) => {
+    if (!fileList) return;
+    setUploadError(null);
+    Array.from(fileList).forEach((f) => uploadMutation.mutate(f));
+  }, [uploadMutation]);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    handleFiles(e.dataTransfer.files);
+  }, [handleFiles]);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(true);
+  };
+
+  const handleDragLeave = () => setDragOver(false);
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
+        <div className="flex items-center gap-2.5">
+          <FolderOpen className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Shared Workspace</h1>
+          {files && files.length > 0 && (
+            <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full">
+              {files.length} {files.length === 1 ? "file" : "files"}
+            </span>
+          )}
+        </div>
+        <Button size="sm" onClick={() => fileInputRef.current?.click()} disabled={uploadMutation.isPending}>
+          <Upload className="h-3.5 w-3.5 mr-1.5" />
+          Upload
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+      </div>
+
+      {/* Error banner */}
+      {uploadError && (
+        <div className="flex items-center gap-2 mx-6 mt-4 px-3 py-2 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive shrink-0">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          {uploadError}
+        </div>
+      )}
+
+      {/* Drop zone + file list */}
+      <div
+        className={cn(
+          "flex-1 min-h-0 overflow-y-auto m-6 rounded-xl border-2 border-dashed transition-colors",
+          dragOver
+            ? "border-primary/50 bg-primary/5"
+            : "border-border/50 bg-card/30",
+        )}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+      >
+        {isLoading ? (
+          <div className="flex items-center justify-center h-40 text-sm text-muted-foreground">
+            Loading files…
+          </div>
+        ) : !files || files.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-40 gap-3 text-center px-6">
+            <FolderOpen className="h-10 w-10 text-muted-foreground/30" />
+            <p className="text-sm font-medium text-muted-foreground">Drop files here or click Upload</p>
+            <p className="text-xs text-muted-foreground/60">
+              Files are stored at <code className="text-xs font-mono bg-muted px-1 py-0.5 rounded">$CREWSPACE_HOME/instances/default/workspace/</code>
+            </p>
+            <p className="text-xs text-muted-foreground/60">
+              Agents can access them via <code className="text-xs font-mono bg-muted px-1 py-0.5 rounded">$CREWSPACE_SHARED_WORKSPACE_DIR</code>
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y divide-border/30 rounded-xl overflow-hidden">
+            {files.map((file) => (
+              <FileRow
+                key={file.name}
+                file={file}
+                companyId={selectedCompanyId!}
+                onDelete={(name) => deleteMutation.mutate(name)}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Upload overlay when dragging */}
+        {dragOver && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <div className="flex flex-col items-center gap-2">
+              <Upload className="h-8 w-8 text-primary" />
+              <span className="text-sm font-medium text-primary">Drop to upload</span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Agent access hint */}
+      <div className="px-6 pb-4 shrink-0">
+        <p className="text-xs text-muted-foreground/50">
+          Files in this workspace are accessible to agents via the terminal as{" "}
+          <code className="font-mono">$CREWSPACE_SHARED_WORKSPACE_DIR</code>. Max file size: 100 MB.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Chat sessions now persist** across navigation and browser refresh — `ChatContext` loads sessions from the server when the company changes, lazy-loads message history when a session is opened, and creates sessions on the server when a new chat is started
- **Messages persisted after send** — `AgentChat` and `ChatSidebar` both call `persistMessage()` after the user sends and after each agent stream finishes, so the full conversation is saved to `chat_messages`
- **Delete / rename sync** — `deleteSession` and `renameSession` now hit the API endpoints in addition to updating local state
- **Shared Workspace page** — new `/workspace` route reachable from the "Intelligence" sidebar section; drag-and-drop or click-to-upload, file listing with download/delete, 100 MB limit
- **`ChatParticipant` type** — lighter participant shape (id, name, icon, status) used in `ChatSession` so server-loaded sessions don't need full `Agent` objects

## Test plan

- [ ] Open Agent Chat, start a conversation, send messages, navigate away and back — sessions and messages still present
- [ ] Refresh browser on `/agent-chat` — sessions and messages survive reload
- [ ] Delete a session in the UI — confirm row removed from `chat_sessions` table
- [ ] Rename a group chat — confirm name updated in DB
- [ ] Navigate to `/workspace` — page loads with empty state and "Upload" button
- [ ] Drag a file onto the workspace — file appears in list and in server's workspace dir
- [ ] Download and delete file via UI
- [ ] TypeScript: `pnpm typecheck` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)