### PR TITLE
fix(installer): spawn powershell.exe directly to fix Windows installation

### DIFF
--- a/desktop-electron/installer/src/main.cjs
+++ b/desktop-electron/installer/src/main.cjs
@@ -7,12 +7,9 @@
 
 const { app, BrowserWindow, ipcMain, shell } = require("electron");
 const path = require("path");
-const { spawn, exec } = require("child_process");
+const { spawn } = require("child_process");
 const os = require("os");
 const fs = require("fs");
-const util = require("util");
-
-const execAsync = util.promisify(exec);
 
 const isDev = process.env.NODE_ENV === "development" || !app.isPackaged;
 
@@ -70,6 +67,23 @@ function createWindow() {
 
 // ── Installation helpers ────────────────────────────────────────────────────
 
+// Use spawn(powershell.exe) directly — avoids cmd.exe newline/quoting issues
+function runPowerShell(script) {
+  return new Promise((resolve, reject) => {
+    const ps = spawn("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let stderr = "";
+    ps.stderr.on("data", (d) => { stderr += d.toString(); });
+    ps.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`PowerShell exited with code ${code}: ${stderr.trim() || "no details"}`));
+    });
+    ps.on("error", reject);
+  });
+}
+
 function getAppDataDir() {
   return path.join(os.homedir(), "AppData", "Local", "CrewSpace");
 }
@@ -81,19 +95,17 @@ function getPayloadPath() {
 }
 
 async function extractZip(zipPath, targetDir, onProgress) {
-  // Ensure target exists
   if (!fs.existsSync(targetDir)) {
     fs.mkdirSync(targetDir, { recursive: true });
   }
 
-  // Use PowerShell Expand-Archive (built into Windows)
   const safeZip = zipPath.replace(/'/g, "''");
   const safeTarget = targetDir.replace(/'/g, "''");
-  const cmd = `powershell -NoProfile -Command "Expand-Archive -Path '${safeZip}' -DestinationPath '${safeTarget}' -Force"`;
 
   onProgress?.({ percent: 5, stage: "extract", detail: "Starting extraction…" });
 
-  await execAsync(cmd);
+  // spawn powershell.exe directly — avoids cmd.exe breaking on newlines/quotes
+  await runPowerShell(`Expand-Archive -Path '${safeZip}' -DestinationPath '${safeTarget}' -Force`);
 
   onProgress?.({ percent: 70, stage: "extract", detail: "Extraction complete" });
 }
@@ -103,15 +115,16 @@ async function createShortcut(exePath, shortcutPath) {
   const safeDir = path.dirname(exePath).replace(/'/g, "''");
   const safeShortcut = shortcutPath.replace(/'/g, "''");
 
-  const ps = `
-    $WshShell = New-Object -comObject WScript.Shell
-    $Shortcut = $WshShell.CreateShortcut('${safeShortcut}')
-    $Shortcut.TargetPath = '${safeExe}'
-    $Shortcut.WorkingDirectory = '${safeDir}'
-    $Shortcut.Save()
-  `;
+  // Single-line script — safe to pass directly to spawn(powershell.exe)
+  const script = [
+    `$w = New-Object -comObject WScript.Shell`,
+    `$s = $w.CreateShortcut('${safeShortcut}')`,
+    `$s.TargetPath = '${safeExe}'`,
+    `$s.WorkingDirectory = '${safeDir}'`,
+    `$s.Save()`,
+  ].join("; ");
 
-  await execAsync(`powershell -NoProfile -Command "${ps.replace(/"/g, '\"')}"`);
+  await runPowerShell(script);
 }
 
 async function createShortcuts(exePath, { desktop = true, startMenu = true } = {}) {

--- a/desktop-electron/installer/src/renderer/App.tsx
+++ b/desktop-electron/installer/src/renderer/App.tsx
@@ -32,7 +32,7 @@ export default function App() {
       if (data.percent >= 100 && data.stage === "done") {
         window.installerAPI.offProgress();
         if (data.detail?.startsWith("Error:")) {
-          setInstallError(data.detail);
+          setInstallError(data.detail.slice("Error: ".length));
         } else {
           setInstallReady(true);
         }
@@ -43,6 +43,12 @@ export default function App() {
       const msg = err instanceof Error ? err.message : String(err);
       setInstallError(msg);
     });
+  }
+
+  function retryInstall() {
+    installStarted.current = false;
+    setInstallError(null);
+    startInstall();
   }
 
   function handleGetStarted() {
@@ -81,6 +87,7 @@ export default function App() {
               installReady={installReady}
               installError={installError}
               onComplete={() => setStep("complete")}
+              onRetry={retryInstall}
             />
           </motion.div>
         )}

--- a/desktop-electron/installer/src/renderer/components/FeatureCarousel.tsx
+++ b/desktop-electron/installer/src/renderer/components/FeatureCarousel.tsx
@@ -8,12 +8,14 @@ interface FeatureCarouselProps {
   installReady: boolean;
   installError: string | null;
   onComplete: () => void;
+  onRetry: () => void;
 }
 
 export default function FeatureCarousel({
   installReady,
   installError,
   onComplete,
+  onRetry,
 }: FeatureCarouselProps) {
   const { index, progress, goTo, next, prev, setPaused } = useCarousel(
     featureSlides.length
@@ -286,14 +288,34 @@ export default function FeatureCarousel({
                   display: "flex",
                   alignItems: "center",
                   gap: 6,
+                  maxWidth: 360,
                 }}
               >
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ flexShrink: 0 }}>
                   <circle cx="7" cy="7" r="6.5" stroke="#c64545" />
                   <line x1="7" y1="4" x2="7" y2="8" stroke="#c64545" strokeWidth="1.5" strokeLinecap="round" />
                   <circle cx="7" cy="10" r="0.75" fill="#c64545" />
                 </svg>
-                Installation failed
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {installError.length > 80 ? installError.slice(0, 80) + "…" : installError}
+                </span>
+                <button
+                  onClick={onRetry}
+                  style={{
+                    flexShrink: 0,
+                    marginLeft: 4,
+                    padding: "2px 8px",
+                    borderRadius: 4,
+                    border: "1px solid #c64545",
+                    background: "transparent",
+                    color: "#c64545",
+                    fontSize: 11,
+                    cursor: "pointer",
+                    fontWeight: 500,
+                  }}
+                >
+                  Retry
+                </button>
               </span>
             ) : installReady ? (
               <span


### PR DESCRIPTION
## Root cause

`createShortcut` passed a multi-line PowerShell script via `child_process.exec`. On Windows, `exec` routes through `cmd.exe` which **breaks the command at the first newline**. The WScript.Shell shortcut script was never executed, throwing an error in Case 1 (zip extraction path) → "Installation failed".

## Fix

- Added `runPowerShell(script)` helper using `spawn('powershell.exe', [args...])` directly — bypasses `cmd.exe` entirely, no newline issue, stderr captured for error messages  
- Applied to both `extractZip` and `createShortcut`
- FeatureCarousel now shows the actual error text (truncated) + **Retry** button

🤖 Generated with [Claude Code](https://claude.com/claude-code)