### PR TITLE
fix(macos): remove duplicate afterSign from mac build section

### DIFF
--- a/desktop-electron/package.json
+++ b/desktop-electron/package.json
@@ -136,8 +136,7 @@
         "dmg"
       ],
       "icon": "assets/icon.png",
-      "identity": null,
-      "afterSign": "scripts/afterSign.cjs"
+      "identity": null
     },
     "dmg": {
       "background": "assets/installer/dmgBackground.png",


### PR DESCRIPTION
`afterSign` was present in both the top-level `build` config (correct) and nested inside `mac` (invalid). electron-builder 25 schema validation rejects unknown properties in the mac section, failing both Windows and macOS CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)