### PR TITLE
feat(updater): seamless auto-update system + fix installer in-place update

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -63,8 +63,12 @@ jobs:
         working-directory: desktop-electron
         run: pnpm run build:renderer
 
-      # Package the main app as an unpacked directory (no NSIS yet —
-      # we'll zip it and hand it to the installer wizard)
+      # Build NSIS installer — generates latest.yml + blockmap for electron-updater
+      - name: Build NSIS installer (auto-update artifacts)
+        working-directory: desktop-electron
+        run: pnpm exec electron-builder --win nsis --publish never
+
+      # Package the main app as an unpacked directory for the installer wizard payload
       - name: Build desktop app (unpacked)
         working-directory: desktop-electron
         run: pnpm exec electron-builder --win --dir --publish never
@@ -90,11 +94,21 @@ jobs:
         working-directory: desktop-electron/installer
         run: pnpm run build:app
 
-      - name: Upload Windows installer artifact
+      - name: Upload Windows installer wizard artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows-installer-wizard
-          path: desktop-electron/installer/dist/CrewSpace-Setup-*.exe
+          path: desktop-electron/installer/dist/CrewSpace-Installer-*.exe
+          retention-days: 30
+
+      - name: Upload NSIS auto-update artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-nsis
+          path: |
+            desktop-electron/dist/CrewSpace-Setup-*.exe
+            desktop-electron/dist/CrewSpace-Setup-*.exe.blockmap
+            desktop-electron/dist/latest.yml
           retention-days: 30
 
   # ── macOS: build DMG ────────────────────────────────────────────────────────
@@ -172,10 +186,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download Windows installer
+      - name: Download Windows installer wizard
         uses: actions/download-artifact@v4
         with:
           name: windows-installer-wizard
+          path: dist/
+
+      - name: Download Windows NSIS auto-update artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-nsis
           path: dist/
 
       - name: Download macOS DMG
@@ -206,11 +226,12 @@ jobs:
           ### Downloads
           | Platform | File | Notes |
           |----------|------|-------|
-          | Windows | `CrewSpace-Setup-*.exe` | Self-contained installer wizard |
+          | Windows (first install) | `CrewSpace-Installer-*.exe` | Beautiful installer wizard |
+          | Windows (silent/update) | `CrewSpace-Setup-*.exe` | Used by auto-updater |
           | macOS | `CrewSpace-*.dmg` | Drag to Applications |
 
           ### Installation
-          **Windows:** Run `CrewSpace-Setup-*.exe`. The wizard will install the app and create desktop + Start Menu shortcuts. Your existing data (companies, agents, projects) is preserved across updates.
+          **Windows:** Run `CrewSpace-Installer-*.exe`. The wizard will install the app and create desktop + Start Menu shortcuts. Your existing data (companies, agents, projects) is preserved across updates. Future updates are delivered automatically — you'll see a notification when a new version is ready to install.
 
           **macOS:** Open the `.dmg` and drag CrewSpace to your Applications folder. If macOS says the app is "damaged", run this in Terminal and then open the app again:
           ```
@@ -226,7 +247,7 @@ jobs:
           - Plugin ecosystem with built-in plugin manager
           - Local-first: all data stays on your machine
           EOF
-          gh release create "$tag" dist/*.exe dist/*.dmg \
+          gh release create "$tag" dist/*.exe dist/*.dmg dist/*.blockmap dist/latest.yml \
             --title "CrewSpace Desktop $tag" \
             --notes-file /tmp/release-notes.md \
             --latest

--- a/desktop-electron/installer/package.json
+++ b/desktop-electron/installer/package.json
@@ -45,7 +45,7 @@
       "icon": "assets/icon.ico"
     },
     "portable": {
-      "artifactName": "CrewSpace-Setup-${version}.exe"
+      "artifactName": "CrewSpace-Installer-${version}.exe"
     }
   }
 }

--- a/desktop-electron/installer/src/main.cjs
+++ b/desktop-electron/installer/src/main.cjs
@@ -198,30 +198,51 @@ ipcMain.handle("install", async () => {
   const targetDir = path.join(os.homedir(), "AppData", "Local", "Programs", "CrewSpace");
 
   try {
-    // ── Case 1: payload zip exists → fresh app extraction ────────────────
+    // ── Case 1: payload zip exists → install / in-place update ──────────
     if (fs.existsSync(zipPath)) {
-      sendProgress(5, "extract", "Preparing installation directory…");
+      const isUpdate = fs.existsSync(targetDir);
+      sendProgress(5, "extract", isUpdate ? "Preparing update…" : "Preparing installation…");
 
-      if (fs.existsSync(targetDir)) {
-        // Kill any running CrewSpace so Windows releases file locks before we delete
-        try {
-          await runPowerShell("Stop-Process -Name 'CrewSpace' -Force -ErrorAction SilentlyContinue");
-          await new Promise((r) => setTimeout(r, 800));
-        } catch (_) {}
+      // Kill running CrewSpace and wait for it to fully exit before touching files.
+      // Using a wait loop avoids the "file locked" error from the old instant-delete approach.
+      try {
+        await runPowerShell(
+          "$proc = Get-Process -Name 'CrewSpace' -ErrorAction SilentlyContinue; " +
+          "if ($proc) { $proc | Stop-Process -Force; Start-Sleep -Seconds 2 }"
+        );
+      } catch (_) {}
 
-        try {
-          fs.rmSync(targetDir, { recursive: true, force: true });
-        } catch (_) {
-          // Locked files (e.g. DLLs in use) — proceed anyway;
-          // Expand-Archive -Force will overwrite everything it can
-          sendProgress(8, "extract", "Updating existing installation…");
-        }
-      }
+      sendProgress(10, "extract", "Extracting files…");
+
+      // Extract to a temp directory first — avoids lock contention on the live install dir
+      const tempDir = path.join(os.tmpdir(), `crewspace-update-${Date.now()}`);
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      const safeZip = zipPath.replace(/'/g, "''");
+      const safeTemp = tempDir.replace(/'/g, "''");
+      await runPowerShell(`Expand-Archive -Path '${safeZip}' -DestinationPath '${safeTemp}' -Force`);
+
+      sendProgress(65, "extract", "Applying update…");
+
+      // electron-builder sometimes nests all files in a subdir inside the zip
+      const tempEntries = fs.readdirSync(tempDir, { withFileTypes: true });
+      const hasExeAtRoot = tempEntries.some((e) => e.name === "CrewSpace.exe");
+      const srcDir = hasExeAtRoot
+        ? tempDir
+        : path.join(tempDir, (tempEntries.find((e) => e.isDirectory()) ?? { name: "" }).name);
+
+      // Robocopy merge: overwrite existing files, copy new ones, keep unrelated extras.
+      // Exit codes 0–7 are success (files copied/skipped); ≥8 means real error.
       fs.mkdirSync(targetDir, { recursive: true });
+      const safeSrc = srcDir.replace(/'/g, "''");
+      const safeDst = targetDir.replace(/'/g, "''");
+      await runPowerShell(
+        `$rc = (Start-Process robocopy -ArgumentList "'${safeSrc}' '${safeDst}' /E /IS /IT /IM /NFL /NDL /NJH /NJS" -Wait -PassThru -NoNewWindow).ExitCode; ` +
+        `if ($rc -ge 8) { exit $rc } else { exit 0 }`
+      );
 
-      await extractZip(zipPath, targetDir, (progress) => {
-        mainWindow?.webContents.send("install-progress", progress);
-      });
+      // Clean up temp
+      try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch (_) {}
 
       let exePath = path.join(targetDir, "CrewSpace.exe");
       if (!fs.existsSync(exePath)) {
@@ -235,7 +256,7 @@ ipcMain.handle("install", async () => {
 
       sendProgress(85, "shortcuts", "Creating shortcuts…");
       await createShortcuts(exePath);
-      sendProgress(100, "done", "Installation complete");
+      sendProgress(100, "done", isUpdate ? "Update complete" : "Installation complete");
       return { success: true, installPath: targetDir, exePath };
     }
 

--- a/desktop-electron/package.json
+++ b/desktop-electron/package.json
@@ -83,6 +83,13 @@
     "appId": "com.crewspaceai.desktop",
     "productName": "CrewSpace",
     "afterSign": "scripts/afterSign.cjs",
+    "publish": {
+      "provider": "github",
+      "owner": "priyansh19",
+      "repo": "CrewSpace",
+      "releaseType": "release"
+    },
+    "updaterCacheDirName": "crewspace-updater",
     "directories": {
       "output": "dist"
     },


### PR DESCRIPTION
## Summary

- **Fixes installer crash on reinstall**: When running the installer wizard over an existing installation, Windows holds file locks on app DLLs. The old code did `Stop-Process` → `rmSync` (instant delete) which failed because the process hadn't fully exited. New approach: extract zip to a temp directory first, then `Robocopy /E /IS /IT /IM` merge into the install dir — no delete needed, no lock contention.
- **Wires up electron-updater**: Adds `publish` GitHub provider config to `desktop-electron/package.json` so `electron-updater` (already fully coded in `main.js`) knows where to fetch `latest.yml` at runtime.
- **Generates auto-update artifacts in CI**: Builds NSIS installer (`--publish never`) to produce `CrewSpace-Setup-*.exe`, `*.blockmap`, and `latest.yml` — all uploaded to the GitHub Release so electron-updater can detect and silently download new versions.
- **Renames wizard artifact** to `CrewSpace-Installer-*.exe` to avoid filename collision with the NSIS `CrewSpace-Setup-*.exe`.

## Test plan

- [ ] Install app fresh with `CrewSpace-Installer-*.exe` wizard — should complete successfully
- [ ] Run installer wizard again while app is open — should complete without "Error: Po..." crash
- [ ] After release, verify GitHub Release contains `latest.yml` file
- [ ] Bump version to `1.0.1` in a future release — open v1.0.0 → should log "update available" in dev console

🤖 Generated with [Claude Code](https://claude.com/claude-code)