### PR TITLE
fix(updater): remove invalid updaterCacheDirName from electron-builder config

### DIFF
--- a/desktop-electron/package.json
+++ b/desktop-electron/package.json
@@ -89,7 +89,6 @@
       "repo": "CrewSpace",
       "releaseType": "release"
     },
-    "updaterCacheDirName": "crewspace-updater",
     "directories": {
       "output": "dist"
     },


### PR DESCRIPTION
electron-builder 25.1.8 rejects `updaterCacheDirName` as an unknown property. Removing it — the auto-updater still works correctly without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)