### PR TITLE
fix(ui): prevent white blank screen on app startup

### DIFF
--- a/desktop-electron/main.js
+++ b/desktop-electron/main.js
@@ -491,6 +491,7 @@ function createWindow() {
     minHeight: 640,
     center: true,
     show: false,
+    backgroundColor: "#faf9f5",
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,


### PR DESCRIPTION
## Summary

Without `backgroundColor` set, Electron renders the native window background as white before the loading screen CSS paints. This causes a blank white screen visible at startup.

Fix: add `backgroundColor: "#faf9f5"` to the `BrowserWindow` options — matches the loading screen canvas color so the window never flashes white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)