### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/desktop-electron/installer/package.json
+++ b/desktop-electron/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewspace-installer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CrewSpace Windows installer wizard",
   "author": "CrewSpaceAI",
   "private": true,

--- a/desktop-electron/package.json
+++ b/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewspace-desktop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CrewSpace — AI agent company control plane",
   "author": "CrewSpace AI <hello@crewspace.ai>",
   "main": "main.js",


### PR DESCRIPTION
Bumps both `desktop-electron` and `installer` packages to v1.0.1 for the white-flash-on-startup fix release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)