### PR TITLE
fix(desktop): resolve white screen on installer launch

### DIFF
--- a/desktop-electron/main.js
+++ b/desktop-electron/main.js
@@ -235,7 +235,8 @@ function spawnServer(port) {
     CREWSPACE_HOME: dataDir,
     HOST: SERVER_BIND_HOST,
     PORT: String(port),
-    SERVE_UI: "false",
+    SERVE_UI: "true",
+    CREWSPACE_RENDERER_DIST: path.join(__dirname, "renderer-dist"),
     CREWSPACE_MIGRATION_AUTO_APPLY: "true",
     CREWSPACE_MIGRATION_PROMPT: "never",
     CREWSPACE_OPEN_ON_LISTEN: "false",
@@ -491,7 +492,7 @@ function createWindow() {
     minHeight: 640,
     center: true,
     show: false,
-    backgroundColor: "#faf9f5",
+    backgroundColor: "#0f172a",
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,
@@ -620,7 +621,7 @@ function createWindow() {
     const url = mainWindow.webContents.getURL();
     handleNavigation(url);
     // Before React mounts: seed localStorage with the saved theme preference
-    if (url.includes("localhost:5285") || url.startsWith("file://")) {
+    if (url.includes("localhost:5285") || url.startsWith("file://") || (serverUrl && url.startsWith(serverUrl))) {
       try {
         const rawTheme = getThemePreference();
         const savedTheme = (rawTheme === "dark" || rawTheme === "light") ? rawTheme : "dark";

--- a/desktop-electron/src/renderer/index.html
+++ b/desktop-electron/src/renderer/index.html
@@ -23,6 +23,7 @@
     <!-- CREWSPACE_FAVICON_END -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
+    <style>html,body,#root{background:#0f172a}html.light,html.light body,html.light #root{background:#faf9f5}</style>
     <script>
       (() => {
         const key = "crewspace.theme";

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -269,6 +269,7 @@ export async function createApp(
   if (opts.uiMode === "static") {
     // Try published location first (server/ui-dist/), then monorepo dev location (../../ui/dist)
     const candidates = [
+      ...(process.env.CREWSPACE_RENDERER_DIST ? [process.env.CREWSPACE_RENDERER_DIST] : []),
       path.resolve(__dirname, "../ui-dist"),
       path.resolve(__dirname, "../../desktop-electron/renderer-dist"),
     ];


### PR DESCRIPTION
## Summary

- **Root cause**: The embedded server was spawned with `SERVE_UI=false`, which set `uiMode="none"`. When `loadRenderer()` navigated the window to `http://127.0.0.1:3150/`, the server had no route to serve the React app — returning nothing, resulting in a blank white page.
- Pass `CREWSPACE_RENDERER_DIST` env var to the server so it knows where to find the built renderer assets bundled inside the Electron app package.
- Fix dark-theme background flash during the loading-screen → renderer page transition.

## Test plan

- [ ] Build the desktop app (`pnpm run build:renderer` then `electron-builder`)
- [ ] Install the generated installer on Windows/macOS
- [ ] Launch the app — confirm the loading screen appears, server starts, and the full React UI renders (no white screen)
- [ ] Confirm dark background during initial load (no cream/white flash)
- [ ] Verify API calls work correctly (agents, projects, dashboard)

https://claude.ai/code/session_01MxDQU8j3xBEz7uXcr3dbQe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxDQU8j3xBEz7uXcr3dbQe)_