### PR TITLE
fix(desktop): v1.0.15 — fix embedded server startup on Node 20

### DIFF
--- a/desktop-electron/installer/package.json
+++ b/desktop-electron/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewspace-installer",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "CrewSpace Windows installer wizard",
   "author": "CrewSpaceAI",
   "private": true,
@@ -34,6 +34,7 @@
       "output": "dist"
     },
     "files": [
+      "package.json",
       "src/main.cjs",
       "src/preload.cjs",
       "renderer-dist/**/*",

--- a/desktop-electron/installer/src/main.cjs
+++ b/desktop-electron/installer/src/main.cjs
@@ -91,8 +91,10 @@ function createWindow() {
 // Extract a ZIP using tar.exe (built into Windows 10 1803+).
 function extractZipToDir(zipPath, targetDir) {
   ensureCleanDir(targetDir);
+  const systemTar = "C:\\Windows\\System32\\tar.exe";
+  const tarPath = fs.existsSync(systemTar) ? systemTar : "tar.exe";
   return new Promise((resolve, reject) => {
-    const proc = spawn("tar.exe", ["-xf", zipPath, "-C", targetDir], {
+    const proc = spawn(tarPath, ["-xf", zipPath, "-C", targetDir], {
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     });
@@ -256,78 +258,14 @@ ipcMain.handle("install", async () => {
 
       sendProgress(10, "extract", "Extracting files…");
 
-      // Extract to a temp directory first — avoids lock contention on the live install dir.
-      // Uses tar.exe (built into Windows 10+) with Expand-Archive fallback.
-      const tempDir = path.join(os.tmpdir(), `crewspace-update-${Date.now()}`);
-      await extractZipToDir(zipPath, tempDir);
+      sendProgress(15, "extract", "Extracting files…");
 
-      sendProgress(65, "extract", "Applying update…");
-
-      // Determine the real source directory inside the extracted temp dir.
-      // electron-builder sometimes nests all files in a subdirectory inside the zip,
-      // so we probe several patterns before falling back to the temp root.
-      const srcDir = (() => {
-        try {
-          const entries = fs.readdirSync(tempDir, { withFileTypes: true });
-          // Case 1: CrewSpace.exe is directly at the zip root — use temp dir
-          if (entries.some((e) => !e.isDirectory() && e.name === "CrewSpace.exe")) {
-            flog(`srcDir: exe at root \u2192 ${tempDir}`);
-            return tempDir;
-          }
-          // Case 2: exactly one sub-directory (common electron-builder layout)
-          const subDirs = entries.filter((e) => e.isDirectory());
-          if (subDirs.length === 1) {
-            const candidate = path.join(tempDir, subDirs[0].name);
-            flog(`srcDir: single subdir \u2192 ${candidate}`);
-            return candidate;
-          }
-          // Case 3: multiple subdirs — look for one containing CrewSpace.exe
-          for (const d of subDirs) {
-            const candidate = path.join(tempDir, d.name);
-            try {
-              const inner = fs.readdirSync(candidate);
-              if (inner.includes("CrewSpace.exe")) {
-                flog(`srcDir: nested subdir with exe \u2192 ${candidate}`);
-                return candidate;
-              }
-            } catch (_) {}
-          }
-          // Fallback: use tempDir itself
-          flog(`srcDir: fallback \u2192 ${tempDir}`);
-          return tempDir;
-        } catch (readErr) {
-          flog(`srcDir detection failed (${readErr.message}), using tempDir`);
-          return tempDir;
-        }
-      })();
-
-      // Validate srcDir is actually a directory before copying
-      try {
-        const srcStat = fs.statSync(srcDir);
-        if (!srcStat.isDirectory()) {
-          throw new Error(
-            `Extracted payload path is not a directory: ${srcDir}. ` +
-            "The installer file may be corrupt — please re-download and try again."
-          );
-        }
-      } catch (statErr) {
-        if (statErr.code === "ENOENT") {
-          throw new Error(
-            "Extraction appeared to succeed but the output directory is missing. " +
-            "This may be a permissions issue with your Temp folder. " +
-            "Please try running the installer again."
-          );
-        }
-        throw statErr;
-      }
-
-      // Copy using Node.js fs.cpSync — no robocopy or PowerShell needed
-      copyDir(srcDir, targetDir);
-
-      // Clean up temp
-      try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch (_) {}
+      // Extract DIRECTLY to target — avoids Node 20 fs.cpSync symlink bugs
+      fs.mkdirSync(targetDir, { recursive: true });
+      await extractZipToDir(zipPath, targetDir);
 
       let exePath = path.join(targetDir, "CrewSpace.exe");
+      // electron-builder zips win-unpacked directly, so exe is at root
       if (!fs.existsSync(exePath)) {
         const entries = fs.readdirSync(targetDir, { withFileTypes: true });
         const subDir = entries.find((e) => e.isDirectory());
@@ -368,14 +306,15 @@ ipcMain.handle("launch-app", async () => {
   const exePath = findInstalledExe();
 
   if (exePath) {
+    const err = await shell.openPath(exePath);
+    if (err === "") return { success: true, launched: exePath };
+    // Fallback only if openPath fails
     try {
       const child = spawn(exePath, [], { detached: true, shell: false, stdio: "ignore" });
       child.unref();
       return { success: true, launched: exePath };
-    } catch (err) {
-      // Fall back to shell.openPath if spawn fails
-      await shell.openPath(exePath);
-      return { success: true, launched: exePath };
+    } catch (spawnErr) {
+      return { success: false, error: String(spawnErr) };
     }
   }
 

--- a/desktop-electron/main.js
+++ b/desktop-electron/main.js
@@ -256,7 +256,9 @@ function spawnServer(port) {
   } else {
     // Production: use bundled Node.js to run the prepared server
     execPath = process.execPath;
-    args = [serverEntry];
+    // Node 20 requires this flag to allow CJS packages that require() ESM deps
+    // (e.g. jsdom/html-encoding-sniffer, @asamuzakjp/css-color, etc.)
+    args = ["--experimental-require-module", serverEntry];
     // Electron executable acts as Node.js when this env var is set
     env.ELECTRON_RUN_AS_NODE = "1";
     console.log("[CrewSpace Desktop] Using bundled server (node + prepared server)");

--- a/desktop-electron/package.json
+++ b/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewspace-desktop",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "CrewSpace \u2014 AI agent company control plane",
   "author": "CrewSpace AI <hello@crewspace.ai>",
   "main": "main.js",
@@ -90,7 +90,7 @@
       "releaseType": "release"
     },
     "directories": {
-      "output": "dist"
+      "output": "dist3"
     },
     "files": [
       "main.js",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
     "typecheck": "pnpm -r typecheck",
     "db:generate": "pnpm --filter @crewspaceai/db generate",
     "db:migrate": "pnpm --filter @crewspaceai/db migrate",
-    "build:desktop": "pnpm -r build && cd desktop-electron && pnpm run build:renderer && pnpm make",
+    "build:desktop": "pnpm -r build && cd desktop-electron && pnpm run build:win",
     "build:installer": "pnpm --filter crewspace-installer build",
     "build:desktop:with-installer": "pnpm build:desktop && pnpm package:payload && pnpm build:installer",
     "package:payload": "node scripts/zip-installer-payload.mjs"
   },
   "devDependencies": {
+    "archiver": "^8.0.0",
     "cross-env": "^10.1.0",
     "esbuild": "^0.27.3",
     "typescript": "^5.7.3",

--- a/scripts/prepare-desktop-server.mjs
+++ b/scripts/prepare-desktop-server.mjs
@@ -14,8 +14,8 @@
  * 7. Restore original workspace package.json files.
  */
 import { execSync } from "node:child_process";
-import { copyFileSync, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 function sleep(ms) {
@@ -65,6 +65,105 @@ const workspacePackages = [
   "packages/adapters/hermes-crewspace-adapter",
   "packages/plugins/sdk",
 ];
+
+/**
+ * pnpm deploy marks many transitive dependencies as "private" in
+ * .modules.yaml — they are only accessible inside .pnpm/ and are not
+ * hoisted to the root node_modules.  When we later dereference symlinks
+ * and delete .pnpm/, those packages become unresolvable.
+ *
+ * This function promotes every package found inside .pnpm/{name}/node_modules/
+ * to the root node_modules/ (as symlinks) so that Node.js module resolution
+ * works after dereferencing.
+ */
+function promoteAllPnpmPackages(nodeModulesDir) {
+  const pnpmDir = join(nodeModulesDir, ".pnpm");
+  if (!existsSync(pnpmDir)) return;
+
+  function promoteDirContents(sourceDir, targetDir) {
+    for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+      const name = entry.name;
+      if (name === ".bin" || name === ".modules.yaml") continue;
+
+      const sourcePath = join(sourceDir, name);
+      const targetPath = join(targetDir, name);
+
+      if (entry.isDirectory()) {
+        if (name.startsWith("@")) {
+          // Scoped packages: always recurse so we don't miss packages
+          // that belong to the same scope but come from different .pnpm entries.
+          mkdirSync(targetPath, { recursive: true });
+          promoteDirContents(sourcePath, targetPath);
+          continue;
+        }
+        if (existsSync(targetPath)) continue;
+        const rel = relative(dirname(targetPath), sourcePath);
+        symlinkSync(rel, targetPath, "dir");
+      } else if (entry.isSymbolicLink()) {
+        if (existsSync(targetPath)) continue;
+        const rel = relative(dirname(targetPath), sourcePath);
+        const s = statSync(sourcePath);
+        symlinkSync(rel, targetPath, s.isDirectory() ? "dir" : "file");
+      }
+    }
+  }
+
+  for (const entry of readdirSync(pnpmDir)) {
+    const pkgNodeModules = join(pnpmDir, entry, "node_modules");
+    if (!existsSync(pkgNodeModules) || !statSync(pkgNodeModules).isDirectory()) {
+      continue;
+    }
+    promoteDirContents(pkgNodeModules, nodeModulesDir);
+  }
+}
+
+/**
+ * Recursively replace all symlinks in a directory tree with the actual
+ * files/directories they point to. This is required before packaging
+ * because pnpm's node_modules contains symlinks into .pnpm/ which
+ * become broken when extracted on a different machine/path.
+ */
+function dereferenceDir(dir) {
+  if (!existsSync(dir)) return;
+
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      // Read the symlink target
+      let target;
+      try {
+        target = readlinkSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      // Resolve relative targets
+      const resolvedTarget = resolve(dir, target);
+      if (!existsSync(resolvedTarget)) {
+        // Broken symlink — remove it
+        rmSync(fullPath, { recursive: true, force: true });
+        continue;
+      }
+
+      // Remove symlink and copy the real content
+      rmSync(fullPath, { recursive: true, force: true });
+      const stat = statSync(resolvedTarget);
+      if (stat.isDirectory()) {
+        cpSync(resolvedTarget, fullPath, { recursive: true, dereference: true });
+      } else {
+        mkdirSync(dirname(fullPath), { recursive: true });
+        copyFileSync(resolvedTarget, fullPath);
+      }
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      dereferenceDir(fullPath);
+    }
+  }
+}
 
 function patchPackageExports(pkgPath) {
   const original = readFileSync(pkgPath, "utf-8");
@@ -199,6 +298,10 @@ function main() {
   try {
     // 3. Deploy server
     const serverProdDir = join(repoRoot, "desktop-electron", "server-prod");
+    if (existsSync(serverProdDir)) {
+      console.log("[prepare-desktop-server] Clearing existing server-prod...");
+      rmSync(serverProdDir, { recursive: true, force: true });
+    }
     console.log("[prepare-desktop-server] Running pnpm deploy...");
     execSync(`pnpm deploy --filter @crewspaceai/server "${serverProdDir}"`, {
       cwd: repoRoot,
@@ -227,6 +330,19 @@ function main() {
     // 5. Patch all deployed @crewspaceai package exports
     console.log("[prepare-desktop-server] Patching deployed package exports...");
     patchAllExportsInDir(deployBase);
+
+    // 5b. Promote private .pnpm packages to root node_modules, then dereference
+    const deployedNodeModules = join(serverProdDir, "node_modules");
+    console.log("[prepare-desktop-server] Promoting private .pnpm packages to root node_modules...");
+    promoteAllPnpmPackages(deployedNodeModules);
+    console.log("[prepare-desktop-server] Dereferencing symlinks in node_modules...");
+    dereferenceDir(deployedNodeModules);
+    // Also remove the .pnpm store since all symlinks to it are now resolved
+    const pnpmStore = join(deployedNodeModules, ".pnpm");
+    if (existsSync(pnpmStore)) {
+      rmSync(pnpmStore, { recursive: true, force: true });
+      console.log("[prepare-desktop-server] Removed .pnpm store");
+    }
 
     // 6. Copy renderer-dist into desktop-electron build artifacts
     // The desktop app bundles renderer-dist directly; server ui-dist is not needed.

--- a/scripts/zip-installer-payload.mjs
+++ b/scripts/zip-installer-payload.mjs
@@ -7,14 +7,14 @@
  *   node scripts/zip-installer-payload.mjs --input desktop-electron/dist/win-unpacked --output desktop-electron/installer/assets/payload/app.zip
  */
 
-import { createWriteStream } from "node:fs";
+import { createWriteStream, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
-import { resolve } from "node:path";
-import archiver from "archiver";
+import { ZipArchive } from "archiver";
 
 const input = process.argv.includes("--input")
   ? process.argv[process.argv.indexOf("--input") + 1]
-  : "desktop-electron/dist/win-unpacked";
+  : "desktop-electron/dist3/win-unpacked";
 
 const output = process.argv.includes("--output")
   ? process.argv[process.argv.indexOf("--output") + 1]
@@ -27,7 +27,9 @@ console.log(`Creating payload zip…`);
 console.log(`  Input:  ${inputPath}`);
 console.log(`  Output: ${outputPath}`);
 
-const archive = archiver("zip", { zlib: { level: 9 } });
+mkdirSync(dirname(outputPath), { recursive: true });
+
+const archive = new ZipArchive({ zlib: { level: 9 } });
 const stream = createWriteStream(outputPath);
 
 archive.on("warning", (err) => {

--- a/server/package.json
+++ b/server/package.json
@@ -70,7 +70,7 @@
     "express": "^5.1.0",
     "express-rate-limit": "^8.5.2",
     "hermes-crewspace-adapter": "workspace:*",
-    "jsdom": "^28.1.0",
+    "jsdom": "27.0.0",
     "multer": "^2.0.2",
     "open": "^11.0.0",
     "pino": "^9.6.0",


### PR DESCRIPTION
## Summary
Fixes the embedded server failing to start in the packaged desktop app.

## Root Causes
1. **Missing transitive dependencies**: 	exttt{pnpm deploy} marks deps of workspace packages as "private" — they live only inside 	exttt{.pnpm/}. When 	exttt{dereferenceDir} removed 	exttt{.pnpm} and converted symlinks to real files, these packages became unresolvable.

2. **ESM/CJS incompatibility with Node 20**: 	exttt{jsdom@28} depends on 	exttt{html-encoding-sniffer@6} which \	exttt{require()}s the ESM-only 	exttt{@exodus/bytes}. Node 24 handles this, but Electron's bundled Node 20.18.3 does not.

## Changes
- 	exttt{scripts/prepare-desktop-server.mjs}: promote private 	exttt{.pnpm} packages to root 	exttt{node_modules} before dereferencing symlinks
- 	exttt{server/package.json}: downgrade 	exttt{jsdom} 28.1.0 → 27.0.0
- 	exttt{desktop-electron/main.js}: pass 	exttt{--experimental-require-module} when spawning server in production
- Installer: hardcode 	exttt{C:\Windows\System32\tar.exe}, extract zip directly to target, prefer 	exttt{shell.openPath}
- Build scripts: fix 	exttt{pnpm make} → 	exttt{pnpm run build:win}

## Verification
- Fresh NSIS install tested: app launches, server starts on port 3150, React UI loads, API endpoints respond
